### PR TITLE
Pullups on to read switches.

### DIFF
--- a/FiveLEDsPuzzle.ino
+++ b/FiveLEDsPuzzle.ino
@@ -32,12 +32,18 @@ void loop () {
     for (int b=0; b<5; b++) {
       int d = DDRB;
       DDRB = d & ~(1<<b);
+      PORTB |= 1 << b;
       delay(1);
       if (!(PINB & 1<<b)) {
         while (!(PINB & 1<<b));
+        PORTB &= ~(1 << b);
         DDRB = d ^ ((!b || (d & ((1<<b)-1)) == 1<<(b-1))<<b);
         Start = millis();
-      } else DDRB = d;
+      }
+      else {
+        PORTB &= ~(1 << b);
+        DDRB = d;
+      }
       delay(10);
     }
   }


### PR DESCRIPTION
It's worthwhile to turn pullup resistors on when reading the switches. Relying on the LEDs as pullups may cause unreliable circuit operation as battery voltage decreases.

Per the ATtiny datasheet, the minimum voltage guaranteed to be interpreted as a high logic level is 0.6Vcc, or 1.8V assuming Vcc=3.0V. Therefore if the LED drops more than about 1.2V, it may not act as a reliable pullup.

When powering the circuit with two NiMH cells (Vcc=2.7V), I switched from red to yellow LEDs, and operation became unreliable. At If=4mA, the yellow LEDs have a Vf of about 1.92V vs. 1.88V for the red. Changing the code to turn on pullups eliminated the issue.

Fun project! I plan to make several copies for friends and family; we'll see if they can figure it out!